### PR TITLE
Importing only lodash modules that are needed

### DIFF
--- a/src/ConflictResolution.js
+++ b/src/ConflictResolution.js
@@ -1,4 +1,4 @@
-const { intersection } = require('lodash');
+const intersection = require('lodash/intersection');
 
 class ConflictResolution {
   constructor({ strategy = 'ps', logger }) {

--- a/src/ConflictResolution.js
+++ b/src/ConflictResolution.js
@@ -1,4 +1,4 @@
-const _ = require('lodash');
+const { intersection } = require('lodash');
 
 class ConflictResolution {
   constructor({ strategy = 'ps', logger }) {
@@ -50,7 +50,7 @@ class ConflictResolution {
 
   resolveBySpecificity(actions) {
     const isMoreSpecific = (action, rhs) => action.premises.length > rhs.premises.length
-      && _.intersection(action.premises, rhs.premises).length === rhs.premises.length;
+      && intersection(action.premises, rhs.premises).length === rhs.premises.length;
     const isMostSpecific = (action, all) => all.reduce((acc, other) => acc
       && !isMoreSpecific(other, action), true);
     const selected = actions.filter(action => isMostSpecific(action, actions));

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -1,4 +1,9 @@
-const _ = require('lodash');
+const {
+  isBoolean,
+  isFunction,
+  isInteger,
+  isString,
+} = require('lodash');
 const assert = require('assert');
 const arrify = require('arrify');
 
@@ -22,7 +27,7 @@ class Rule {
       '"name" is required',
     );
     assert(
-      _.isString(this.name),
+      isString(this.name),
       '"name" must be a string',
     );
     assert(
@@ -30,7 +35,7 @@ class Rule {
       '"when" is required with at least one premise',
     );
     assert(
-      this.when.reduce((acc, premise) => acc && _.isFunction(premise), true),
+      this.when.reduce((acc, premise) => acc && isFunction(premise), true),
       '"when" must be a function or an array of functions',
     );
     assert(
@@ -38,15 +43,15 @@ class Rule {
       '"then" is required',
     );
     assert(
-      _.isFunction(this.then),
+      isFunction(this.then),
       '"then" must be a function',
     );
     assert(
-      _.isInteger(this.priority),
+      isInteger(this.priority),
       '"priority" must be an integer',
     );
     assert(
-      _.isBoolean(this.final),
+      isBoolean(this.final),
       '"final" must be a boolean',
     );
     assert(
@@ -54,7 +59,7 @@ class Rule {
       '"extend" must be a Rule or an array of Rules',
     );
     assert(
-      !this.activationGroup || _.isString(this.activationGroup),
+      !this.activationGroup || isString(this.activationGroup),
       '"activationGroup" must be a string',
     );
   }

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -1,9 +1,7 @@
-const {
-  isBoolean,
-  isFunction,
-  isInteger,
-  isString,
-} = require('lodash');
+const isBoolean = require('lodash/isBoolean');
+const isFunction = require('lodash/isFunction');
+const isInteger = require('lodash/isInteger');
+const isString = require('lodash/isString');
 const assert = require('assert');
 const arrify = require('arrify');
 


### PR DESCRIPTION
The following changes were made:
- Require only intersection in ConflictResolution.js
- Require only isBoolean, isFunction, isInteger, isString in Rule.js

Also, for the require section at the top of Rule.js you have an ESLint rule that forced it to be formatted that way. As I didn't want to affect anything else other than the specific items I wanted to update. Thanks!