### PR TITLE
Add RuleError which can wrap a thrown error

### DIFF
--- a/src/Rools.js
+++ b/src/Rools.js
@@ -4,6 +4,7 @@ const Delegator = require('./Delegator');
 const WorkingMemory = require('./WorkingMemory');
 const ConflictResolution = require('./ConflictResolution');
 const observe = require('./observe');
+const RuleError = require('./RuleError');
 
 class Rools {
   constructor({ logging } = {}) {
@@ -100,7 +101,7 @@ class Rools {
       await action.fire(facts); // >>> fire action!
     } catch (error) { // re-throw error!
       this.logger.error({ message: 'error in action (then)', rule: action.name, error });
-      throw new Error(`error in action (then): ${action.name}`, error);
+      throw new RuleError(`error in action (then): ${action.name}`, error);
     } finally {
       delegator.unset();
     }

--- a/src/RuleError.js
+++ b/src/RuleError.js
@@ -1,0 +1,8 @@
+class RuleError extends Error {
+  constructor(message, error) {
+    super(message);
+    this.cause = error;
+  }
+}
+
+module.exports = RuleError;


### PR DESCRIPTION
Error doesn't have a constructor which accepts another error as an argument, which appears to be what was intended on line 103.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

This PR creates a custom error which does. Now you can access the original error (otherwise it disappears silently).