### PR TITLE
feat: export RuleError

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,10 @@ export class Rule {
   constructor(opts: RuleOptions);
 }
 
+export class RuleError {
+  constructor(message: string, error: Error);
+}
+
 export interface RuleOptions {
   name: string;
   when: Premise | Premise[];

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const Rools = require('./Rools');
 const Rule = require('./Rule');
+const RuleError = require('./RuleError');
 
-module.exports = { Rools, Rule };
+module.exports = { Rools, Rule, RuleError };


### PR DESCRIPTION
Export `RuleError` to better support usecases where error is thrown during rule evaluation for early exit. Once exported, `RuleError` can be used as an accurate indication of rule violation (via the `instanceof` check).